### PR TITLE
Fix the minimum decimals for consistency.

### DIFF
--- a/index.js
+++ b/index.js
@@ -322,9 +322,11 @@
 
     return {
       prefix: prefix,
-      value: power === undefined
+      value: (
+        power === undefined
         ? value / factor
         : Math.round(value * power / factor) / power
+      ).toFixed(decimals)
     }
   }
 


### PR DESCRIPTION
e.g. decimals=1 for 100, 100.549, and 100.56 yields 100.0, 100.5, 100.6

Currently, setting decimals=1 and formatting a value of 100 yields 100 instead of 100.0