### PR TITLE
feat(types): better TypeScript typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,93 +1,112 @@
-type BinaryPrefix = "" | "Ki" | "Mi" | "Gi" | "Ti" | "Pi" | "Ei" | "Zi" | "Yi";
+declare module "human-format" {
+  export type BinaryPrefix =
+    | ""
+    | "Ki"
+    | "Mi"
+    | "Gi"
+    | "Ti"
+    | "Pi"
+    | "Ei"
+    | "Zi"
+    | "Yi";
 
-type SIPrefix =
-  | "y"
-  | "z"
-  | "a"
-  | "f"
-  | "p"
-  | "n"
-  | "µ"
-  | "m"
-  | ""
-  | "k"
-  | "M"
-  | "G"
-  | "T"
-  | "P"
-  | "E"
-  | "Z"
-  | "Y";
+  export type SIPrefix =
+    | "y"
+    | "z"
+    | "a"
+    | "f"
+    | "p"
+    | "n"
+    | "µ"
+    | "m"
+    | ""
+    | "k"
+    | "M"
+    | "G"
+    | "T"
+    | "P"
+    | "E"
+    | "Z"
+    | "Y";
 
-export type ScaleName = "binary" | "SI";
+  export type ScaleName = "binary" | "SI";
 
-export type Scale<T extends string> = humanFormat.Scale<T>;
+  export type ScaleLike = Scale<string> | ScaleName;
 
-export type ScaleLike = Scale<string> | ScaleName;
+  export type Prefix<TScale extends ScaleLike> = TScale extends Scale<
+    infer TPrefix
+  >
+    ? TPrefix
+    : TScale extends "binary"
+    ? BinaryPrefix
+    : TScale extends "SI"
+    ? SIPrefix
+    : never;
 
-export type Prefix<S extends ScaleLike> = S extends Scale<infer U>
-  ? U
-  : S extends "binary"
-  ? BinaryPrefix
-  : S extends "SI"
-  ? SIPrefix
-  : never;
-
-export declare interface Options<S extends ScaleLike> {
-  maxDecimals?: number | "auto";
-  separator?: string;
-  unit?: string;
-  scale?: S;
-  strict?: boolean;
-  prefix?: Prefix<S>;
-  decimals?: number;
-}
-
-export declare interface Info<S extends ScaleLike> {
-  value: number;
-  prefix: Prefix<S>;
-  unit?: string;
-}
-
-export declare interface ParsedInfo<S extends ScaleLike> {
-  value: number;
-  factor: number;
-  prefix: Prefix<S>;
-  unit?: string;
-}
-
-export declare function humanFormat<S extends ScaleLike>(
-  value: number,
-  opts?: Options<S>
-): string;
-
-export declare namespace humanFormat {
-  function bytes<S extends ScaleLike>(value: number, opts?: Options<S>): string;
-
-  function parse<S extends ScaleLike>(str: string, opts?: Options<S>): number;
-
-  namespace parse {
-    function raw<S extends ScaleLike>(
-      str: string,
-      opts?: Options<S>
-    ): ParsedInfo<S>;
+  export interface Options<TScale extends ScaleLike> {
+    maxDecimals?: number | "auto";
+    separator?: string;
+    unit?: string;
+    scale?: TScale;
+    strict?: boolean;
+    prefix?: Prefix<TScale>;
+    decimals?: number;
   }
 
-  function raw<S extends ScaleLike>(value: number, opts?: Options<S>): Info<S>;
-
-  class Scale<P extends string> {
-    constructor(prefixes: Record<P, number>);
+  export interface Info<TScale extends ScaleLike> {
+    value: number;
+    prefix: Prefix<TScale>;
+    unit?: string;
   }
 
-  namespace Scale {
-    function create<P extends string>(
-      prefixes: P[],
+  export interface ParsedInfo<TScale extends ScaleLike> {
+    value: number;
+    factor: number;
+    prefix: Prefix<TScale>;
+    unit?: string;
+  }
+
+  export class Scale<TPrefix extends string> {
+    constructor(prefixes: Record<TPrefix, number>);
+    static create<TPrefix extends string>(
+      prefixes: TPrefix[],
       base: number,
       initExp?: number
-    ): Scale<P>;
+    ): Scale<TPrefix>;
+    findPrefix(value: number): { factor: number; prefix: TPrefix };
+    parse<TScale extends ScaleLike>(
+      str: string,
+      strict?: boolean
+    ): ParsedInfo<TScale>;
   }
 
-  export { bytes, parse, raw, Prefix, BinaryPrefix, Scale };
-}
+  interface HumanFormat {
+    <TScale extends ScaleLike>(
+      value: number,
+      options?: Options<TScale>
+    ): string;
+    bytes<TScale extends ScaleLike>(
+      value: number,
+      options?: Options<TScale>
+    ): string;
+    parse: {
+      <TScale extends ScaleLike>(
+        str: string,
+        options?: Options<TScale>
+      ): number;
+      raw<TScale extends ScaleLike>(
+        str: string,
+        strict?: boolean
+      ): ParsedInfo<TScale>;
+    };
+    raw<TScale extends ScaleLike>(
+      value: number,
+      options?: Options<TScale>
+    ): Info<TScale>;
+    Scale: typeof Scale;
+  }
 
-export default humanFormat;
+  const humanFormat: HumanFormat;
+
+  export = humanFormat;
+}


### PR DESCRIPTION
This PR enhances TypeScript typing.

- Allowing direct import of class/contants

  ```ts
  import { Scale, raw } from 'human-format'
  ```

- Fixing error:

  > _Using exported name `humanFormat` as identifier for default export_

  ```ts
  import humanFormat from 'human-format'
         ^^^^^^^^^^^
  ```

- Fixing error:

  > _Caution: `humanFormat` also has a named export `Scale`. Check if you meant to write `import { Scale } from 'human-format'` instead_


  ```ts
  import humanFormat from 'human-format'

  const scale = humanFormat.Scale.create(...)
                            ^^^^^
  ```
